### PR TITLE
Support authenticating proxies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,8 @@ export default function fetch (url, opts = {}) {
         if (opts.user && opts.password) {
           callback(opts.user, opts.password)
         } else {
-          callback()
+          req.abort()
+          reject(new FetchError(`login event received from ${authInfo.host} but no credentials provided`))
         }
       })
     }

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,17 @@ export default function fetch (url, opts = {}) {
       }, request.timeout)
     }
 
+    if (request.useElectronNet) {
+      // handle authenticating proxies
+      req.on('login', (authInfo, callback) => {
+        if (opts.user && opts.password) {
+          callback(opts.user, opts.password)
+        } else {
+          callback()
+        }
+      })
+    }
+
     req.on('error', err => {
       clearTimeout(reqTimeout)
       reject(new FetchError(`request to ${request.url} failed, reason: ${err.message}`, 'system', err))


### PR DESCRIPTION
Electron's `net` module supports authenticating proxies out of the box, however, we need to listen to an [additional event](https://electron.atom.io/docs/api/client-request/#event-login) and invoke a callback, otherwise the proxied request becomes a black-holed request.

This is pretty rudimentary but we'll just check the options passed to the request for `user` and `password` fields. If those fields aren't provided we'll abort the request and bubble up an error.