### PR TITLE
Add typings for the commonjs module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ node_modules
 .DS_Store
 
 # Babel-compiled files
-lib
+lib/**/*
 .idea/
+
+# typescript declarations
+!lib/**/*.d.ts

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,125 @@
+import { Stream, Readable } from 'stream';
+
+export = fetch;
+
+declare function fetch(
+  url: string,
+  options?: fetch.RequestInit
+): Promise<fetch.Response>;
+
+declare namespace fetch {
+
+  export class FetchError extends Error {
+  }
+
+  export type HeadersInit = Headers | string[][] | { [key: string]: string };
+  export class Headers {
+    constructor(init?: HeadersInit);
+
+    append(name: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+
+    // WebIDL pair iterator: iterable<ByteString, ByteString>
+    entries(): IterableIterator<[string, string]>;
+    forEach(callback: (value: string, name: string, headers: Headers) => void, thisArg?: any): void;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    [Symbol.iterator](): IterableIterator<[string, string]>;
+  }
+
+  export type BodyInit = Stream | string | Blob | Buffer | null;
+  export interface Body {
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    formData(): Promise<FormData>;
+    json<T = any>(): Promise<T>;
+    text(): Promise<string>;
+    buffer(): Promise<Buffer>;
+  }
+
+  export class Response implements Body {
+    constructor(body: BodyInit, init?: ResponseInit);
+
+    readonly url: string;
+    readonly status: number;
+    readonly ok: boolean;
+    readonly statusText: string;
+    readonly headers: Headers;
+    readonly body: Readable | string;
+
+    clone(): Response;
+
+    // Body impl
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    formData(): Promise<FormData>;
+    json<T = any>(): Promise<T>;
+    text(): Promise<string>;
+    buffer(): Promise<Buffer>;
+  }
+
+  export interface RequestInit {
+    // These properties are part of the Fetch Standard
+    method?: string;
+    headers?: HeadersInit;
+    body: BodyInit;
+    // (/!\ only works when running on Node.js) set to `manual` to extract redirect headers, `error` to reject redirect
+    redirect?: RequestRedirect;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // The following properties are electron-fetch extensions
+
+    // (/!\ only works when running on Node.js) maximum redirect count. 0 to not follow redirect
+    follow?: number;
+    // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
+    timeout?: number;
+    // maximum response body size in bytes. 0 to disable
+    size?: number;
+    session?: Electron.Session;
+    useElectronNet?: boolean;
+    // When running on Electron behind an authenticated HTTP proxy, username to use to authenticate
+    user?: string;
+    // When running on Electron behind an authenticated HTTP proxy, password to use to authenticate
+    password?: string;
+  }
+  export type RequestInfo = Request | string;
+  export class Request implements Body {
+    constructor(input: RequestInfo, init?: RequestInit);
+
+    readonly method: string;
+    readonly url: string;
+    readonly headers: Headers;
+
+    readonly redirect: RequestRedirect;
+
+    clone(): Request;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // The following properties are electron-fetch extensions
+
+    // (/!\ only works when running on Node.js) maximum redirect count. 0 to not follow redirect
+    follow: number;
+    // (/!\ only works when running on Node.js)
+    counter: number;
+    // (/!\ only works when running on Electron)
+    session?: Electron.Session;
+    // (/!\ only works when running on Electron, throws when set to true on Node.js)
+    useElectronNet: boolean;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Body impl
+    readonly bodyUsed: boolean;
+    arrayBuffer(): Promise<ArrayBuffer>;
+    blob(): Promise<Blob>;
+    formData(): Promise<FormData>;
+    json<T = any>(): Promise<T>;
+    text(): Promise<string>;
+    buffer(): Promise<Buffer>;
+    readonly body: Readable;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.0",
   "description": "A light-weight module that brings window.fetch to electron's background process",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "module": "lib/index.es.js",
   "files": [
     "lib/index.js",


### PR DESCRIPTION
Add type declarations for the puplic API of the commonjs module. These
type declaration are _not_ compatible with the es2015 module, because of
the `exports = fetch` hack.
***
I put the declarations file directly in the lib folder; is this ok or should it go somewhere else and be copied to the lib folder on build/publish?