### PR TITLE
Export `fetch` as default in TypeScript

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
 import { Stream, Readable } from 'stream';
 
-export = fetch;
+export default fetch;
 
 declare function fetch(
   url: string,


### PR DESCRIPTION
This solves https://github.com/arantes555/electron-fetch/issues/6
