### PR TITLE
Added `options.onLogin` handler for advanced proxy-authentication

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -86,6 +86,23 @@ declare namespace fetch {
     user?: string;
     // When running on Electron behind an authenticated HTTP proxy, password to use to authenticate
     password?: string;
+    onLogin?: (
+        event: PreventableEvent,
+        authInfo: AuthInfo,
+        callback: (username: string, password: string) => void
+    ) => void;
+  }
+  export interface PreventableEvent {
+    defaultPrevented: boolean;
+    preventDefault(): void;
+  }
+  // This comes from the Electron namespace:
+  export interface AuthInfo {
+      isProxy: boolean;
+      scheme: string;
+      host: string;
+      port: number;
+      realm: string;
   }
   export type RequestInfo = Request | string;
   export class Request implements Body {

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,14 @@ export default function fetch (url, opts = {}) {
         if (opts.user && opts.password) {
           callback(opts.user, opts.password)
         } else {
+          if (opts.onLogin) {
+            const ev = new PreventableEvent();
+            opts.onLogin(ev, authInfo, callback);
+            if (ev.defaultPrevented) {
+              // If the handler called `preventDefault()`, they're handling the callback
+              return;
+            }
+          }
           req.abort()
           reject(new FetchError(`login event received from ${authInfo.host} but no credentials provided`, 'proxy', {code: 'PROXY_AUTH_FAILED'}))
         }
@@ -202,6 +210,15 @@ export default function fetch (url, opts = {}) {
 
     writeToStream(req, request)
   }))
+}
+
+class PreventableEvent {
+  constructor() {
+    this.defaultPrevented = false;
+  }
+  preventDefault() {
+    this.defaultPrevented = true;
+  }
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -1968,6 +1968,30 @@ const createTestSuite = (useElectronNet) => {
             })
           })
       })
+
+      it('should connect through authenticated proxy with onLogin callback', () => {
+        url = `${base}plain`
+        return waitForSessions
+          .then(() => fetch(url, {
+            useElectronNet,
+            session: authenticatedProxySession,
+            onLogin (ev, authInfo, authCallback) {
+              ev.preventDefault()
+
+              setTimeout(() => {
+                authCallback('testuser', 'testpassword')
+              }, 10)
+            }
+          }))
+          .then(res => {
+            expect(res.headers.get('content-type')).to.equal('text/plain')
+            return res.text().then(result => {
+              expect(res.bodyUsed).to.be.true
+              expect(result).to.be.a('string')
+              expect(result).to.equal('text')
+            })
+          })
+      })
     }
   })
 


### PR DESCRIPTION
This is in response to https://github.com/arantes555/electron-fetch/issues/9

# What
Adds the `onLogin` option.
The `onLogin` option can be used for acquiring proxy-credentials in an async manner (eg. prompting the user).

