### PR TITLE
Force first write with chunked stream body

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -388,6 +388,10 @@ export function writeToStream (dest, instance) {
     // body is stream
     if (instance.useElectronNet) {
       dest.chunkedEncoding = instance.chunkedEncoding
+
+      // Force a first write to start the request otherwise an empty body stream
+      // will cause an error when closing the dest stream with Electron v7.
+      dest.write('')
     }
     body.pipe(new PassThrough()) // I have to put a PassThrough because somehow, FormData streams are not eaten by electron/net
       .pipe(dest)

--- a/test/test.js
+++ b/test/test.js
@@ -829,6 +829,31 @@ const createTestSuite = (useElectronNet) => {
       })
     })
 
+    it('should allow POST request with empty readable stream as body', function () {
+      const body = new stream.PassThrough().end()
+
+      url = `${base}inspect`
+      opts = {
+        method: 'POST',
+        body,
+        useElectronNet
+      }
+
+      return fetch(url, opts).then(res => {
+        return res.json()
+      }).then(res => {
+        expect(res.method).to.equal('POST')
+        expect(res.body).to.equal('')
+        expect(res.headers['content-type']).to.be.undefined
+        if (useElectronNet) {
+          expect(res.headers['transfer-encoding']).to.equal('chunked')
+          expect(res.headers['content-length']).to.be.undefined
+        } else {
+          expect(res.headers['content-length']).to.eql('0')
+        }
+      })
+    })
+
     it('should allow POST request with form-data as body', function () {
       const form = new FormData()
       form.append('a', '1')

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,9 @@ const deepEqual = (value, expectedValue) => {
 }
 const deepIteratesOver = (value, expectedValue) => deepEqual(Array.from(value), Array.from(expectedValue))
 
+const isElectronGreaterThan = (majorVersion) =>
+  process.versions.electron && Number(process.versions.electron.split('.')[0]) >= majorVersion
+
 before(done => {
   local.start(() =>
     unauthenticatedProxy.start(() =>
@@ -200,20 +203,22 @@ const createTestSuite = (useElectronNet) => {
       })
     })
 
-    it('should accept custom host header', function () {
-      url = `${base}inspect`
-      opts = {
-        headers: {
-          host: 'example.com'
-        },
-        useElectronNet
-      }
-      return fetch(url, opts).then(res => {
-        return res.json()
-      }).then(res => {
-        expect(res.headers.host).to.equal('example.com')
+    if (!useElectronNet || !isElectronGreaterThan(7)) {
+      it('should accept custom host header', function () {
+        url = `${base}inspect`
+        opts = {
+          headers: {
+            host: 'example.com'
+          },
+          useElectronNet
+        }
+        return fetch(url, opts).then(res => {
+          return res.json()
+        }).then(res => {
+          expect(res.headers.host).to.equal('example.com')
+        })
       })
-    })
+    }
 
     it('should accept connection header', function () {
       url = `${base}inspect`


### PR DESCRIPTION
In Electron v7, `net` requests with chunked stream bodies need to be
initialized with a first write to be closable.
If nothing is ever written to the source stream, Electron will raise
an error when closing it (this can be considered a bug).

By forcing a first write (with an empty string) to the source stream,
we make sure the request is initialized and can be closed.

This Pull Request also makes sure the custom host header test is not 
expected to pass with Electron v7 since Electron does not allow 
setting this header in `net` requests anymore.