### PR TITLE
implement opts.signal/AbortController support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,6 +89,7 @@ export interface RequestInit {
   method?: string
   headers?: HeadersInit
   body?: BodyInit
+  signal: AbortSignal
   // (/!\ only works when running on Node.js) set to `manual` to extract redirect headers, `error` to reject redirect
   redirect?: RequestRedirect
 
@@ -121,6 +122,7 @@ export class Request implements Body {
   readonly headers: Headers
 
   readonly redirect: RequestRedirect
+  readonly signal: AbortSignal
 
   clone (): Request
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,6 +1152,15 @@
       "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
@@ -2630,6 +2639,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
     },
     "external-editor": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/core": "^7.11.4",
     "@babel/preset-env": "^7.11.0",
     "@babel/register": "^7.10.5",
+    "abort-controller": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-istanbul": "^6.0.0",
     "basic-auth-parser": "0.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,13 @@ export default function fetch (url, opts = {}) {
       let body = new PassThrough()
       res.on('error', err => body.emit('error', err))
       res.pipe(body)
+
+      if (opts.signal && request.useElectronNet) {
+        opts.signal.addEventListener('abort', () => {
+          body.end()
+        })
+      }
+
       const responseOptions = {
         url: request.url,
         status: res.statusCode,

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,12 @@ export default function fetch (url, opts = {}) {
     }
     let reqTimeout
 
+    if (opts.signal) {
+      opts.signal.addEventListener('abort', () => {
+        req.abort()
+      })
+    }
+
     if (request.timeout) {
       reqTimeout = setTimeout(() => {
         req.abort()

--- a/src/request.js
+++ b/src/request.js
@@ -58,6 +58,7 @@ export default class Request {
     // fetch spec options
     this.method = method.toUpperCase()
     this.redirect = init.redirect || input.redirect || 'follow'
+    this.signal = init.signal || input.signal || null
     this.headers = new Headers(init.headers || input.headers || {})
     this.headers.delete('Content-Length') // user cannot set content-length themself as per fetch spec
     this.chunkedEncoding = false

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ import { parse as parseURL } from 'url'
 import { URL } from 'whatwg-url' // TODO: remove
 import * as fs from 'fs'
 import assert from 'assert'
+import AbortController from 'abort-controller'
 
 import { TestProxy, TestServer } from './server'
 // test subjects
@@ -647,6 +648,54 @@ const createTestSuite = (useElectronNet) => {
         expect(res.ok).to.be.true
         return expect(res.text()).to.eventually.be.rejectedWith(FetchError)
           .and.have.property('type', 'body-timeout')
+      })
+    })
+
+    it('should handle aborts before request', function () {
+      this.timeout(500)
+      const abort = new AbortController()
+      abort.abort()
+      url = `${base}timeout`
+      opts = {
+        useElectronNet,
+        signal: abort.signal
+      }
+      return expect(fetch(url, opts)).to.eventually.be.rejected
+        .and.be.an.instanceOf(FetchError)
+        .and.have.property('type', 'abort')
+    })
+
+    it('should handle aborts during a request', function () {
+      this.timeout(500)
+      const abort = new AbortController()
+      setTimeout(() => {
+        abort.abort()
+      }, 100)
+      url = `${base}timeout`
+      opts = {
+        useElectronNet,
+        signal: abort.signal
+      }
+      return expect(fetch(url, opts)).to.eventually.be.rejected
+        .and.be.an.instanceOf(FetchError)
+        .and.have.property('type', 'abort')
+    })
+
+    it('should handle aborts during a response', function () {
+      this.timeout(500)
+      const abort = new AbortController()
+      setTimeout(() => {
+        abort.abort()
+      }, 100)
+      url = `${base}slow`
+      opts = {
+        useElectronNet,
+        signal: abort.signal
+      }
+      return fetch(url, opts).then(res => {
+        expect(res.ok).to.be.true
+        return expect(res.text()).to.eventually.be.rejectedWith(FetchError)
+          .and.to.satisfy(e => e.message.endsWith('request aborted'))
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -652,7 +652,6 @@ const createTestSuite = (useElectronNet) => {
     })
 
     it('should handle aborts before request', function () {
-      this.timeout(500)
       const abort = new AbortController()
       abort.abort()
       url = `${base}timeout`
@@ -666,7 +665,6 @@ const createTestSuite = (useElectronNet) => {
     })
 
     it('should handle aborts during a request', function () {
-      this.timeout(500)
       const abort = new AbortController()
       setTimeout(() => {
         abort.abort()
@@ -682,7 +680,6 @@ const createTestSuite = (useElectronNet) => {
     })
 
     it('should handle aborts during a response', function () {
-      this.timeout(500)
       const abort = new AbortController()
       setTimeout(() => {
         abort.abort()
@@ -697,6 +694,35 @@ const createTestSuite = (useElectronNet) => {
         return expect(res.text()).to.eventually.be.rejectedWith(FetchError)
           .and.to.satisfy(e => e.message.endsWith('request aborted'))
       })
+    })
+
+    it('should handle aborts after request finish', function () {
+      const abort = new AbortController()
+      url = `${base}hello`
+      opts = {
+        useElectronNet,
+        signal: abort.signal
+      }
+
+      return fetch(url, opts).then(r => r.text()).then(r => {
+        abort.abort()
+      })
+    })
+
+    it('should handle aborts after request error', function () {
+      const abort = new AbortController()
+      url = `${base}error/reset`
+      opts = {
+        useElectronNet,
+        signal: abort.signal
+      }
+
+      return expect(fetch(url, opts)).to.eventually.be.rejected
+        .and.be.an.instanceOf(FetchError)
+        .and.have.property('code', 'ECONNRESET')
+        .then(() => {
+          abort.abort()
+        })
     })
 
     it('should clear internal timeout on fetch response', function (done) { // these tests don't make much sense on electron..


### PR DESCRIPTION
So far this has only been tested on nodejs with `abort-controller` package.

Docs, examples and tests need to be updated accordingly.

I have no idea how closely it resembles the behaviour of AbortController support in whatwg fetch spec either. This needs to be tested/verified as well.

I will report any further findings after rolling out this patched version in our codebase.

Fixes #23 