### PR TITLE
Use Electron's session cookies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ export default function fetch (url, opts = {}) {
       headers = options.headers
       delete options.headers
       options.session = opts.session || electron.session.defaultSession // we have to use a persistent session here, because of https://github.com/electron/electron/issues/13587
+      options.useSessionCookies = true
     } else {
       if (opts.agent) options.agent = opts.agent
     }

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default function fetch (url, opts = {}) {
       headers = options.headers
       delete options.headers
       options.session = opts.session || electron.session.defaultSession // we have to use a persistent session here, because of https://github.com/electron/electron/issues/13587
-      options.useSessionCookies = true
+      options.useSessionCookies = request.useSessionCookies
     } else {
       if (opts.agent) options.agent = opts.agent
     }
@@ -156,7 +156,8 @@ export default function fetch (url, opts = {}) {
         headers: headers,
         size: request.size,
         timeout: request.timeout,
-        useElectronNet: request.useElectronNet
+        useElectronNet: request.useElectronNet,
+        useSessionCookies: request.useSessionCookies
       }
 
       // HTTP-network fetch step 16.1.2

--- a/src/request.js
+++ b/src/request.js
@@ -72,6 +72,12 @@ export default class Request {
       this.useElectronNet = Boolean(process.versions.electron)
     }
 
+    if (this.useElectronNet) {
+      this.useSessionCookies = init.useSessionCookies !== undefined
+        ? init.useSessionCookies
+        : input.useSessionCookies
+    }
+
     if (init.body != null) {
       const contentType = extractContentType(this)
       if (contentType !== null && !this.headers.has('Content-Type')) {

--- a/test/server.js
+++ b/test/server.js
@@ -340,6 +340,13 @@ export class TestServer {
       })
       req.pipe(parser)
     }
+
+    if (p === '/setCookies') {
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/plain')
+      res.setHeader('Set-Cookie', ['type=ninja', 'language=javascript'])
+      res.end('text')
+    }
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2004,7 +2004,7 @@ const createTestSuite = (useElectronNet) => {
           })
       })
 
-      it('should send cookies stored in session', function () {
+      it('should send cookies stored in session if requested', function () {
         url = `${base}setCookies`
         return waitForSessions
           .then(() => fetch(url, {
@@ -2045,6 +2045,93 @@ const createTestSuite = (useElectronNet) => {
           .then(res => res.json())
           .then(res => {
             expect(res.headers.cookie).to.equal('type=ninja; language=javascript')
+          })
+      })
+
+      it('should not send cookies stored in session by default', function () {
+        url = `${base}setCookies`
+        return waitForSessions
+          .then(() => fetch(url, {
+            useElectronNet,
+            session: unauthenticatedProxySession
+          }))
+          .then(res => {
+            return unauthenticatedProxySession.cookies.get({}).then(cookies =>
+              assert(deepEqual(cookies, [
+                {
+                  domain: 'localhost',
+                  hostOnly: true,
+                  httpOnly: false,
+                  name: 'type',
+                  path: '/',
+                  secure: false,
+                  session: true,
+                  value: 'ninja'
+                },
+                {
+                  domain: 'localhost',
+                  hostOnly: true,
+                  httpOnly: false,
+                  name: 'language',
+                  path: '/',
+                  secure: false,
+                  session: true,
+                  value: 'javascript'
+                }
+              ]))
+            )
+          })
+          .then(() => fetch(`${base}inspect`, {
+            useElectronNet,
+            session: unauthenticatedProxySession
+          }))
+          .then(res => res.json())
+          .then(res => {
+            expect(res.headers.cookie).to.equal(undefined)
+          })
+      })
+
+      it('should not send cookies stored in session if asked not to', function () {
+        url = `${base}setCookies`
+        return waitForSessions
+          .then(() => fetch(url, {
+            useElectronNet,
+            session: unauthenticatedProxySession
+          }))
+          .then(res => {
+            return unauthenticatedProxySession.cookies.get({}).then(cookies =>
+              assert(deepEqual(cookies, [
+                {
+                  domain: 'localhost',
+                  hostOnly: true,
+                  httpOnly: false,
+                  name: 'type',
+                  path: '/',
+                  secure: false,
+                  session: true,
+                  value: 'ninja'
+                },
+                {
+                  domain: 'localhost',
+                  hostOnly: true,
+                  httpOnly: false,
+                  name: 'language',
+                  path: '/',
+                  secure: false,
+                  session: true,
+                  value: 'javascript'
+                }
+              ]))
+            )
+          })
+          .then(() => fetch(`${base}inspect`, {
+            useElectronNet,
+            useSessionCookies: false,
+            session: unauthenticatedProxySession
+          }))
+          .then(res => res.json())
+          .then(res => {
+            expect(res.headers.cookie).to.equal(undefined)
           })
       })
     }

--- a/test/test.js
+++ b/test/test.js
@@ -2003,6 +2003,50 @@ const createTestSuite = (useElectronNet) => {
             })
           })
       })
+
+      it('should send cookies stored in session', function () {
+        url = `${base}setCookies`
+        return waitForSessions
+          .then(() => fetch(url, {
+            useElectronNet,
+            session: unauthenticatedProxySession
+          }))
+          .then(res => {
+            return unauthenticatedProxySession.cookies.get({}).then(cookies =>
+              assert(deepEqual(cookies, [
+                {
+                  domain: 'localhost',
+                  hostOnly: true,
+                  httpOnly: false,
+                  name: 'type',
+                  path: '/',
+                  secure: false,
+                  session: true,
+                  value: 'ninja'
+                },
+                {
+                  domain: 'localhost',
+                  hostOnly: true,
+                  httpOnly: false,
+                  name: 'language',
+                  path: '/',
+                  secure: false,
+                  session: true,
+                  value: 'javascript'
+                }
+              ]))
+            )
+          })
+          .then(() => fetch(`${base}inspect`, {
+            useElectronNet,
+            useSessionCookies: true,
+            session: unauthenticatedProxySession
+          }))
+          .then(res => res.json())
+          .then(res => {
+            expect(res.headers.cookie).to.equal('type=ninja; language=javascript')
+          })
+      })
     }
   })
 


### PR DESCRIPTION
Fixes #21 

In order for `net` requests to match a `fetch` request cookie
behavior, an option can now be passed to use the session cookie store
(see https://github.com/electron/electron/pull/22704).

To keep the default interfaces as close as possible between the Node
and the Electron usages, we add a new Request `useSessionCookies`
option to tell `electron-fetch` whether it should use the stored
Electron's session cookies or not.

This option matches the Electron `net` `useSessionCookies` option.

By default, the option will be disabled.