### PR TITLE
fix: abort request when abort signal received

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,13 @@ export default function fetch (url, opts = {}) {
 
       const abortBody = () => {
         res.destroy()
+
+        if (request.useElectronNet) {
+          req.abort()
+        } else {
+          req.destroy()
+        }
+
         res.emit('error', new FetchError('request aborted', 'abort')) // separated from the `.destroy()` because somehow Node's IncomingMessage streams do not emit errors on destroy
       }
 

--- a/test/server.js
+++ b/test/server.js
@@ -126,6 +126,30 @@ export class TestServer {
       }, 1000)
     }
 
+    if (p === '/never-ending') {
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/plain')
+
+      const interval = setInterval(() => {
+        res.write('hello ' + Date.now())
+      })
+
+      let aborted = false
+
+      setTimeout(() => {
+        if (!aborted) {
+          clearInterval(interval)
+          res.end()
+          throw new Error('request was not aborted')
+        }
+      }, 1000)
+
+      req.once('aborted', () => {
+        aborted = true
+        clearInterval(interval)
+      })
+    }
+
     if (p === '/slow') {
       res.statusCode = 200
       res.setHeader('Content-Type', 'text/plain')

--- a/test/test.js
+++ b/test/test.js
@@ -685,6 +685,28 @@ const createTestSuite = (useElectronNet) => {
         })
     })
 
+    it('should handle aborts during a never ending request', function () {
+      const abort = new AbortController()
+      url = `${base}never-ending`
+      opts = {
+        useElectronNet,
+        signal: abort.signal
+      }
+      assert.isUndefined(abort.signal.listeners.abort)
+      return fetch(url, opts)
+        .then(res => {
+          setTimeout(() => {
+            abort.abort()
+          }, 100)
+
+          return res.text()
+        })
+        .catch(err => {
+          expect(err).to.have.property('message').that.matches(/request aborted/)
+          assert.deepEqual(abort.signal.listeners.abort, [])
+        })
+    })
+
     it('should handle aborts during a response', function () {
       const abort = new AbortController()
       setTimeout(() => {


### PR DESCRIPTION
In the case where responses don't end immediately, abort/destroy the request as well as the response as otherwise the connection is left open and the server never receives the 'abort' event for the request.

I noticed this as I've got some http endpoints that send data over time rather than finishing up the request immediately, the solution seems to be to close the request stream on the client as well as the response body stream.