### PR TITLE
Renderer doesnt have electron.app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,9 @@ let electron
 if (process.versions.electron) {
   electron = require('electron')
 }
-const isReady = electron && electron.app && electron.app.isReady() 
+const isReady = electron && electron.app && electron.app.isReady()
   ? new Promise(resolve => electron.app.once('ready', resolve))
-  : Promise.resolve();
+  : Promise.resolve()
 
 /**
  * Fetch function

--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,9 @@ let electron
 if (process.versions.electron) {
   electron = require('electron')
 }
-const isReady = (!electron || electron.app.isReady())
-  ? Promise.resolve()
-  : new Promise(resolve => electron.app.once('ready', resolve))
+const isReady = electron && electron.app && electron.app.isReady() 
+  ? new Promise(resolve => electron.app.once('ready', resolve))
+  : Promise.resolve();
 
 /**
  * Fetch function


### PR DESCRIPTION
When feature testing to choose native fetch or electron-fetch, renderer still runs the `isReady` and fails because electron renderer doesnt have the electron.app this PR fixes this problem.