### PR TITLE
Add check to not silently ignore the agent option if useElectronNet is enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,8 @@ export default function fetch (url, opts = {}) {
     // send request
     let headers
     if (request.useElectronNet) {
+      if (opts.agent) reject(new Error('"agent" option is only supported with "useElectronNet" disabled'))
+
       headers = options.headers
       delete options.headers
       options.session = opts.session || electron.session.defaultSession

--- a/test/test.js
+++ b/test/test.js
@@ -350,6 +350,13 @@ const createTestSuite = (useElectronNet) => {
             expect(resBody.headers['user-agent']).to.satisfy(s => s.startsWith('electron-fetch/1.0 electron'))
           })
       })
+
+      it('should not allow the agent option', function () {
+        url = `${base}inspect`
+        opts = { agent: 'fake agent' }
+        return expect(fetch(url, opts)).to.eventually.be.rejected
+          .and.be.an.instanceOf(Error, '"agent" option is only supported with "useElectronNet" disabled')
+      })
     } else {
       it('should obey maximum redirect, reject case', function () { // Not compatible with electron.net
         url = `${base}redirect/chain`


### PR DESCRIPTION
Addresses https://github.com/arantes555/electron-fetch/issues/34 to raise an error if the agent option is passed but not supported.