### PR TITLE
fetch type defintion should accept RequestInfo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ import { Agent } from 'https'
 export default fetch
 
 declare function fetch (
-  url: string,
+  url: RequestInfo,
   options?: RequestInit
 ): Promise<Response>
 


### PR DESCRIPTION
This PR Updates the Typescript type definition for `fetch` to take `RequestInfo` as the first parameter, allowing a `Request` object to be passed to `fetch` in place of a URL string.