### PR TITLE
onLogin handler for providing proxy credentials to net request

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ const defaultOptions = {
 	useSessionCookies: true, // (/!\ only works when running on Electron >= 7) Whether or not to automatically send cookies from session.,
 	user: undefined,    // When running on Electron behind an authenticated HTTP proxy, username to use to authenticate
 	password: undefined // When running on Electron behind an authenticated HTTP proxy, password to use to authenticate
+	onLogin: undefined // When running on Electron behind an authenticated HTTP proxy, handler of electron.ClientRequest's login event. Can be used for acquiring proxy credentials in an async manner (e.g. prompting the user).
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ fetch('http://httpbin.org/post', { method: 'POST', body: form, headers: form.get
 	const json = await res.json()
 	console.log(json)
 })()
+
+// providing proxy credentials (electron-specific)
+
+fetch(url, {
+  onLogin (authInfo) { // this 'authInfo' is the one received by the 'login' event. See https://www.electronjs.org/docs/latest/api/client-request#event-login
+    return Promise.resolve({ username: 'testuser', password: 'testpassword' })
+  }
+}))
 ```
 
 See [test cases](https://github.com/arantes555/electron-fetch/blob/master/test/test.js) for more examples.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Readable, Stream } from 'stream'
-import { Session } from 'electron'
+import { AuthInfo, Session } from 'electron'
 import { Agent } from 'https'
 
 export default fetch
@@ -110,6 +110,11 @@ export interface RequestInit {
   user?: string
   // When running on Electron behind an authenticated HTTP proxy, password to use to authenticate
   password?: string
+  /**
+   * When running on Electron behind an authenticated HTTP proxy, handler of `electron.ClientRequest`'s `login` event.
+   * Can be used for acquiring proxy credentials in an async manner (e.g. prompting the user).
+   */
+  onLogin?: (authInfo: AuthInfo) => Promise<{ username: string, password: string } | undefined>
 }
 
 export type RequestInfo = Request | string

--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,9 @@ export default function fetch (url, opts = {}) {
             } else {
               callback()
             }
+          }).catch(error => {
+            cancelRequest()
+            reject(error)
           })
         } else {
           cancelRequest()

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ export default function fetch (url, opts = {}) {
       options.useSessionCookies = request.useSessionCookies
     } else {
       if (opts.agent) options.agent = opts.agent
+      if (opts.onLogin) reject(new Error('"onLogin" option is only supported with "useElectronNet" enabled'))
     }
     const req = send(options)
     if (request.useElectronNet) {
@@ -109,9 +110,17 @@ export default function fetch (url, opts = {}) {
       req.on('login', (authInfo, callback) => {
         if (opts.user && opts.password) {
           callback(opts.user, opts.password)
+        } else if (opts.onLogin) {
+          opts.onLogin(authInfo).then(credentials => {
+            if (credentials) {
+              callback(credentials.username, credentials.password)
+            } else {
+              callback()
+            }
+          })
         } else {
           cancelRequest()
-          reject(new FetchError(`login event received from ${authInfo.host} but no credentials provided`, 'proxy', { code: 'PROXY_AUTH_FAILED' }))
+          reject(new FetchError(`login event received from ${authInfo.host} but no credentials or onLogin handler provided`, 'proxy', { code: 'PROXY_AUTH_FAILED' }))
         }
       })
     }

--- a/test/test.js
+++ b/test/test.js
@@ -2071,7 +2071,7 @@ const createTestSuite = (useElectronNet) => {
           }))
 
       afterEach('Clear authenticated proxy session auth cache', () => {
-        return parseInt(process.versions.electron) < 6
+        return parseInt(process.versions.electron) < 7
           ? new Promise(resolve => authenticatedProxySession.clearAuthCache({ type: 'password' }, () => resolve()))
           : authenticatedProxySession.clearAuthCache()
       })

--- a/test/test.js
+++ b/test/test.js
@@ -2165,6 +2165,20 @@ const createTestSuite = (useElectronNet) => {
           })
       })
 
+      it('should fail through authenticated proxy when onLogin handler rejects', () => {
+        url = `${base}plain`
+        return waitForSessions
+          .then(() => expect(
+            fetch(url, {
+              useElectronNet,
+              session: authenticatedProxySession,
+              onLogin (authInfo) {
+                return Promise.reject(new Error('onLogin failed'))
+              }
+            })
+          ).to.eventually.be.rejectedWith(Error, 'onLogin failed'))
+      })
+
       it('should send cookies stored in session if requested', function () {
         if (parseInt(process.versions.electron) < 7) return this.skip()
         url = `${base}cookie`


### PR DESCRIPTION
This is another attempt at https://github.com/arantes555/electron-fetch/issues/9, an improved version of the long-open PR https://github.com/arantes555/electron-fetch/pull/10.

I added an `onLogin` option, which can be used for acquiring proxy credentials in an async manner (e.g. prompting the user), similarly to using `app.on('login')` in the renderer process.