### PR TITLE
Fix FetchError Types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,10 @@ declare function fetch (
   options?: RequestInit
 ): Promise<Response>
 
-export class FetchError extends Error {}
+export class FetchError extends Error {
+  type: string;
+  code?: number;
+}
 
 export type HeadersInit = Headers | string[][] | { [key: string]: string }
 


### PR DESCRIPTION
FetchError is always called with a type, which I need to use to differentiate errors in my consuming application. Added the correct types based on the implementation.